### PR TITLE
Move getUrl and getModified

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,6 @@ module.exports = plugin;
 function plugin(options) {
     options = options || {};
 
-    var getUrl = toFn(options.urlProperty),
-        getModified = toFn(options.modifiedProperty);
-
     var templatesDir = __dirname + '/templates';
 
     defaultsDeep(options, {
@@ -31,6 +28,9 @@ function plugin(options) {
             changefreq: 'daily'
         }
     });
+    
+    var getUrl = toFn(options.urlProperty),
+        getModified = toFn(options.modifiedProperty);
 
     var entryTemplate = fs.readFileSync(options.entryTemplate, {encoding: 'utf8'});
     var sitemapTemplate = fs.readFileSync(options.sitemapTemplate, {encoding: 'utf8'});


### PR DESCRIPTION
Must be moved after call to defaultsDeep or else options.urlProperty and options.modifiedProperty will be undefined unless specified in the plugin options.