### PR TITLE
Reduce dependencies, ignore drafts, auto set lastModified

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    Handlebars = require('handlebars'),
     _ = require('lodash'),
     moment = require('moment'),
     toFn = require('to-function'),
@@ -35,8 +34,8 @@ function plugin(options) {
     var entryTemplate = fs.readFileSync(options.entryTemplate, {encoding: 'utf8'});
     var sitemapTemplate = fs.readFileSync(options.sitemapTemplate, {encoding: 'utf8'});
 
-    entryTemplate = Handlebars.compile(entryTemplate);
-    sitemapTemplate = Handlebars.compile(sitemapTemplate);
+    entryTemplate = _.template(entryTemplate);
+    sitemapTemplate = _.template(sitemapTemplate);
 
     return function(files, metalsmith, done) {
         var entries,

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function plugin(options) {
                      lastModified = moment(data.stats.mtime).format("YYYY-MM-DD");
                 }
                 else {
-                    return;
+                    lastModified = moment(Date.now()).format("YYYY-MM-DD");
                 }
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function plugin(options) {
         entries = _(Object.keys(files)).map(function (file) {
             data = files[file];
 
-            if (!shouldIgnore(file) || data.private) {
+            if (!shouldIgnore(file) || data.private || data.draft) {
                 return;
             }
 

--- a/lib/templates/entry.xml
+++ b/lib/templates/entry.xml
@@ -1,6 +1,6 @@
-<url>
-    <loc>{{loc}}</loc>{{#if lastmod}}
-    <lastmod>{{lastmod}}</lastmod>{{/if}}{{#if changefreq}}
-    <changefreq>{{changefreq}}</changefreq>{{/if}}{{#if priority}}
-    <priority>{{priority}}</priority>{{/if}}
-</url>
+    <url>
+        <loc><%= loc %></loc><% if (lastmod){ %>
+        <lastmod><%= lastmod %></lastmod><% } %><% if (changefreq){ %>
+        <changefreq><%= changefreq %></changefreq><% } %><% if (priority){ %>
+        <priority><%= priority %></priority><% } %>
+    </url>

--- a/lib/templates/sitemap.xml
+++ b/lib/templates/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{{{entries}}}
+<%= entries %>
 </urlset>

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "homepage": "https://github.com/ExtraHop/metalsmith-sitemap",
   "dependencies": {
-    "handlebars": "^2.0.0-alpha.4",
-    "lodash": "^2.4.1",
+    "lodash": "^3.9",
     "moment": "^2.8.4",
     "to-function": "2.0.5"
   }


### PR DESCRIPTION
- switched to lodash template
    - fix: I don't use handlebars but I do use lodash. One less dependency by removing it. We all win?
- ignore file.drafts
    - fix: drafts we're being included
- set lastModified to Date.now() if it doesn't exist on the file
    - fix: Some of my automatically generated pages did not have a modified time and were being ignored