### PR TITLE
add root url to sitemap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function plugin(options) {
             changefreq: 'daily'
         }
     });
-    
+
     var getUrl = toFn(options.urlProperty),
         getModified = toFn(options.modifiedProperty);
 
@@ -60,7 +60,7 @@ function plugin(options) {
                 return done(e);
             }
 
-            if (!theUrl) {
+            if (theUrl === undefined || theUrl === null) {
                 return;
             }
 


### PR DESCRIPTION
In #4 it was mentioned that there could be multiple files with `file.path == ‘’`. I haven’t come across that.

Submitting this pr just in case you’re interested in pulling this in.

It could also just be added via the options.root object.

Thoughts?