### PR TITLE
Added possibility to choose which key should be used for priority on files

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Allows you to choose which property to use as the canonical url in the frontmatt
 
 Allows you to choose which property to use for ignoring a file in the frontmatter. This accepts nested properties in dot notation via [lodash.get](https://lodash.com/docs#get).
 
+##### priorityProperty
+
+* `optional`
+* `default: priority`
+
+Allows you to choose which property to use for your sitemap priority in the frontmatter. This accepts nested properties in dot notation via [lodash.get](https://lodash.com/docs#get).
+
 
 ## Frontmatter
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ module.exports = plugin;
  *   @property {String} urlProperty (optional)
  *   @property {String} modifiedProperty (optional)
  *   @property {String} privateProperty (optional)
+ *   @property {String} priorityProperty (optional)
  * @return {Function}
  */
 function plugin(opts){
@@ -60,6 +61,7 @@ function plugin(opts){
   var urlProperty = opts.urlProperty || 'canonical';
   var modifiedProperty = opts.modifiedProperty || 'lastmod';
   var privateProperty = opts.privateProperty || 'private';
+  var priorityProperty = opts.priorityProperty || 'priority'; 
 
   /**
    * Main plugin function
@@ -119,7 +121,7 @@ function plugin(opts){
       // Create the sitemap entry (reject keys with falsy values)
       var entry = pick({
         changefreq: frontmatter.changefreq || changefreq,
-        priority: frontmatter.priority || priority,
+        priority: get(frontmatter, priorityProperty) || priority,
         lastmod: get(frontmatter, modifiedProperty) || lastmod
       }, identity);
 

--- a/test/fixtures/custom-frontmatter/expected/sitemap.xml
+++ b/test/fixtures/custom-frontmatter/expected/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-<url> <loc>https://www.example.com/canonical-test</loc> <lastmod>2014-12-01</lastmod> <changefreq>always</changefreq> <priority>1.0</priority> </url>
+<url> <loc>https://www.example.com/canonical-test</loc> <lastmod>2014-12-01</lastmod> <changefreq>always</changefreq> <priority>0.6</priority> </url>
 </urlset>

--- a/test/fixtures/custom-frontmatter/src/index.html
+++ b/test/fixtures/custom-frontmatter/src/index.html
@@ -4,5 +4,6 @@ changefreq: always
 lastModified: 2014-12-01 12:00:00
 seo:
   canonical: https://www.example.com/canonical-test
+order: 0.6
 ---
 Hello

--- a/test/index.js
+++ b/test/index.js
@@ -118,12 +118,13 @@ describe('metalsmith-sitemap', function(){
       });
   });
 
-  it('should allow a canonical url and lastmod to be set from custom property', function(done){
+  it('should allow a canonical url, lastmod and priority to be set from custom property', function(done){
     Metalsmith('test/fixtures/custom-frontmatter')
       .use(sitemap({
         hostname: 'http://www.website.com',
         modifiedProperty: 'lastModified',
-        urlProperty: 'seo.canonical'
+        urlProperty: 'seo.canonical',
+        priorityProperty: 'order'
       }))
       .build(function(err){
         if (err) {


### PR DESCRIPTION
If you're using priority for something completely else on your files, it would be good to have the ability to change what key this plugin uses.