### PR TITLE
Travis integration

### DIFF
--- a/.travis
+++ b/.travis
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"
+  - "iojs"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # metalsmith-sitemap
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
 
 > A metalsmith plugin for generating a sitemap
 
@@ -137,3 +139,10 @@ private: true
 ## License
 
 MIT
+
+
+[npm-badge]: https://img.shields.io/npm/v/metalsmith-sitemap.svg
+[npm-url]: https://www.npmjs.com/package/metalsmith-sitemap
+
+[travis-badge]: https://travis-ci.org/ExtraHop/metalsmith-sitemap.svg?branch=master
+[travis-url]: https://travis-ci.org/ExtraHop/metalsmith-sitemap


### PR DESCRIPTION
Added `.travis` which is the config for TravisCI to use. I left out Node `v0.12` because that requires flags with metalsmith to run and it is [nearing the end of its life](https://github.com/nodejs/LTS#nodejs-long-term-support-working-group).

Also added badges for when Travis is up and running.

To get Travis working, ExtraHop will need to run through steps **1** and **2** in the [Getting Started Guide](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A).
By merging this PR should trigger the CI.