### PR TITLE
Fix regex issue on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,13 +111,8 @@ function plugin(opts){
       return replaceBackslash(file);
     }
 
-    var separatorRegex = new RegExp(path.sep, 'g');
     function replaceBackslash(url) {
-      if (path.sep != '/') {
-        return url.replace(separatorRegex, '/');
-      }
-
-      return url;
+      return url.replace(/\\/g, '/');
     }
 
     Object.keys(files).forEach(function(file) {


### PR DESCRIPTION
`RegExp(path.sep, 'g')` throws an error on Windows. Changing to `RegExp('\\' + path.sep, 'g')` fixes the regex for Windows and has no side effects on Linux.